### PR TITLE
Bugfixes for extra spaces and wrong order on the web scraper

### DIFF
--- a/Team_Roster/immaculateGridCalculations/gridSolver.py
+++ b/Team_Roster/immaculateGridCalculations/gridSolver.py
@@ -515,7 +515,7 @@ def solveGrid(questions):
         elif "World Series Champ" in currentQuestion:
             subquery = getWorldSeriesChamp()
         else:
-            print("ERROR: INVALID QUESTION!!!!")
+            print(f"ERROR: INVALID QUESTION: {currentQuestion}")
             #Create a subquery type that won't return anything
             subquery= db.session.query(
                 literal_column('TRUE').label('INVALID_QUESTION'),

--- a/Team_Roster/immaculateGridCalculations/webScraper.py
+++ b/Team_Roster/immaculateGridCalculations/webScraper.py
@@ -1,4 +1,5 @@
 import requests
+import re
 from bs4 import BeautifulSoup
 
 def scrapeImmaculateGridQuestions(url):
@@ -18,12 +19,27 @@ def scrapeImmaculateGridQuestions(url):
     questionsRow = []
     for e in content:
         # Split the questions and append to the questions array
+        print(str(e.attrs['aria-label']))
         questionStr = str(e.attrs['aria-label']).split(" + ", 1)
         # print(str(e.attrs['aria-label']).split(" + ", 1))
-        questionsRow.append(questionStr[0].rstrip())
-        questionsCol.append(questionStr[1].rstrip())
+
+        rowQuestion = prepQuestionString(questionStr[0])
+        if rowQuestion not in questionsRow:
+            questionsRow.append(rowQuestion)
+        columnQuestion = prepQuestionString(questionStr[1])
+        if columnQuestion not in questionsCol:
+            questionsCol.append(columnQuestion)
     # questions = ["Detroit Tigers","200+ K Season","≤ 3.00 ERA Career","Gold Glove", "Played First Base min. 1 game", "Houston Astros"]
     # Remove duplicates from both sets, append into questionsCol, giving columns precedence
-    questionsCol = list(set(questionsCol))
-    questionsCol += list(set(questionsRow))
+    questionsCol = list(questionsCol)
+    questionsCol += list(questionsRow)
+
     return questionsCol
+
+def prepQuestionString(questionStr):
+    str = questionStr.rstrip() #remove trailing whitespace
+    # remove repeated spaces
+    str = re.sub(r'\s{2,}', ' ', str)
+    return str
+
+


### PR DESCRIPTION
Fixed two bugs:
- sometimes what we receive from the webscraper has extra spaces between words. Added some regex to remove those.
- Using a set is great for storing unique values, but it doesn't retain order. Changed to just manually checking for duplicates so we can retain the same order as the official grid.