### PR TITLE
Added AB to null check for batting

### DIFF
--- a/app/pages/depthChart.py
+++ b/app/pages/depthChart.py
@@ -295,6 +295,7 @@ def getBattingStats(teamId, year):
                     func.sum(Batting.b_SH) +
                     func.sum(Batting.b_SF)
             ).label("PA"),
+            func.sum(Batting.b_AB).label("AB"),
             func.sum(Batting.b_HR).label("HR"),
             func.sum(Batting.b_SB).label("SB"),
             (func.sum(Batting.b_BB) / func.sum(Batting.b_AB)).label("BB"),
@@ -384,6 +385,7 @@ def getBattingStats(teamId, year):
             subquery.c.player_id,
             subquery.c["G"],
             subquery.c.PA,
+            subquery.c.AB,
             subquery.c.HR,
             subquery.c.SB,
             subquery.c["BB"],
@@ -409,6 +411,7 @@ def getBattingStats(teamId, year):
             "player_id": result.player_id,
             "G": result.G,
             "PA": result.PA or 0,
+            "AB": result.AB or 0,
             "HR": result.HR or 0,
             "SB": result.SB or 0,
             "BB%": result.BB or 0,

--- a/app/pages/roster.py
+++ b/app/pages/roster.py
@@ -138,6 +138,7 @@ def getBattingStats(teamId, year):
                     func.sum(Batting.b_SH) +
                     func.sum(Batting.b_SF)
             ).label("PA"),
+            func.sum(Batting.b_AB).label("AB"),
             func.sum(Batting.b_HR).label("HR"),
             func.sum(Batting.b_SB).label("SB"),
             (func.sum(Batting.b_BB) / func.sum(Batting.b_AB)).label("BB"),
@@ -227,6 +228,7 @@ def getBattingStats(teamId, year):
             subquery.c.player_id,
             subquery.c["G"],
             subquery.c.PA,
+            subquery.c["AB"],
             subquery.c.HR,
             subquery.c.SB,
             subquery.c["BB"],
@@ -252,6 +254,7 @@ def getBattingStats(teamId, year):
             "player_id": result.player_id,
             "G": result.G,
             "PA": result.PA or 0,
+            "AB": result.AB or 0,
             "HR": result.HR or 0,
             "SB": result.SB or 0,
             "BB%": result.BB or 0,

--- a/app/templates/depthChart.html
+++ b/app/templates/depthChart.html
@@ -109,82 +109,82 @@
 </body>
 
 <script>
- document.addEventListener("DOMContentLoaded", () => {
-    const positionsData = JSON.parse('{{ positions_stats|tojson }}');
-    const positionMap = {
-        P: "box-pitcher",
-        C: "box-catcher",
-        "1B": "box-firstbase",
-        "2B": "box-secondbase",
-        "3B": "box-thirdbase",
-        SS: "box-shortstop",
-        LF: "box-leftfield",
-        CF: "box-centerfield",
-        RF: "box-rightfield",
-        OF: "box-outfield"
-    };
-    let createOF = false;
+    document.addEventListener("DOMContentLoaded", () => {
+        const positionsData = JSON.parse('{{ positions_stats|tojson }}');
+        const positionMap = {
+            P: "box-pitcher",
+            C: "box-catcher",
+            "1B": "box-firstbase",
+            "2B": "box-secondbase",
+            "3B": "box-thirdbase",
+            SS: "box-shortstop",
+            LF: "box-leftfield",
+            CF: "box-centerfield",
+            RF: "box-rightfield",
+            OF: "box-outfield"
+        };
+        let createOF = false;
 
-    const playerBoxesContainer = document.getElementById('player-boxes');
-    playerBoxesContainer.innerHTML = '';
+        const playerBoxesContainer = document.getElementById('player-boxes');
+        playerBoxesContainer.innerHTML = '';
 
-    // Check if LF, CF, and RF have any data
-    const lfHasData = positionsData['LF'] && positionsData['LF'].length > 0;
-    const cfHasData = positionsData['CF'] && positionsData['CF'].length > 0;
-    const rfHasData = positionsData['RF'] && positionsData['RF'].length > 0;
+        // Check if LF, CF, and RF have any data
+        const lfHasData = positionsData['LF'] && positionsData['LF'].length > 0;
+        const cfHasData = positionsData['CF'] && positionsData['CF'].length > 0;
+        const rfHasData = positionsData['RF'] && positionsData['RF'].length > 0;
 
-    if (!lfHasData && !cfHasData && !rfHasData) {
-        // Create the "OF" box if none of the outfield positions have data
-        createOF = true;
-    }
-
-    for (const [position, players] of Object.entries(positionsData)) {
-        if (position === 'OF' && createOF == false){
-            continue;
-        }else if((position === 'RF' || position == 'CF' || position == 'LF') && createOF == true){
-            continue;
+        if (!lfHasData && !cfHasData && !rfHasData) {
+            // Create the "OF" box if none of the outfield positions have data
+            createOF = true;
         }
 
-        const boxId = positionMap[position];
-        const box = document.createElement('div');
-        box.id = boxId;
-        box.classList.add('player-box');
-        const header = document.createElement('div');
-        header.classList.add('position-header');
-        header.innerHTML = `<span class="position-label">${position}</span>`;
-        box.appendChild(header);
+        for (const [position, players] of Object.entries(positionsData)) {
+            if (position === 'OF' && createOF == false) {
+                continue;
+            } else if ((position === 'RF' || position == 'CF' || position == 'LF') && createOF == true) {
+                continue;
+            }
 
-        const playerList = document.createElement('ul');
-        players.forEach(player => {
-            const listItem = document.createElement('li');
-            listItem.innerHTML = `${player.nameFirst} ${player.nameLast} - ${getStatValue(player)}`;
-            playerList.appendChild(listItem);
-        });
-        box.appendChild(playerList);
-        playerBoxesContainer.appendChild(box);
+            const boxId = positionMap[position];
+            const box = document.createElement('div');
+            box.id = boxId;
+            box.classList.add('player-box');
+            const header = document.createElement('div');
+            header.classList.add('position-header');
+            header.innerHTML = `<span class="position-label">${position}</span>`;
+            box.appendChild(header);
+
+            const playerList = document.createElement('ul');
+            players.forEach(player => {
+                const listItem = document.createElement('li');
+                listItem.innerHTML = `${player.nameFirst} ${player.nameLast} - ${getStatValue(player)}`;
+                playerList.appendChild(listItem);
+            });
+            box.appendChild(playerList);
+            playerBoxesContainer.appendChild(box);
+        }
+    });
+
+    function getStatValue(player) {
+        const stat = document.getElementById('stat').value;
+
+        let statValue = parseFloat(player.stat_value);
+
+        // Check if the conversion resulted in a valid number
+        if (isNaN(statValue)) {
+            return 'N/A'; // Return 'N/A' if stat_value is invalid or can't be converted to a number
+        }
+
+        if (stat === 'percentage') {
+            return `${statValue.toFixed(1)}%`;
+        } else if (stat === 'wOBA') {
+            return statValue.toFixed(3);
+        } else if (stat === 'WAR') {
+            return statValue.toFixed(1);
+        } else {
+            return statValue;
+        }
     }
-});
-
-function getStatValue(player) {
-    const stat = document.getElementById('stat').value;
-
-    let statValue = parseFloat(player.stat_value);
-
-    // Check if the conversion resulted in a valid number
-    if (isNaN(statValue)) {
-        return 'N/A'; // Return 'N/A' if stat_value is invalid or can't be converted to a number
-    }
-
-    if (stat === 'percentage') {
-        return `${statValue.toFixed(1)}%`;
-    } else if (stat === 'wOBA') {
-        return statValue.toFixed(3);
-    } else if (stat === 'WAR') {
-        return statValue.toFixed(1);
-    } else {
-        return statValue;
-    }
-}
 
 </script>
 
@@ -210,7 +210,7 @@ function getStatValue(player) {
             </thead>
             <tbody>
                 {% for player_id, batter in batting_stats.items() %}
-                {% if batter.PA > 0 %}
+                {% if batter.PA > 0 or batter.AB > 0 %}
                 <tr>
                     <td>
                         <a href={{"https://www.baseball-reference.com/players/{}/{}.shtml".format(player_id[0],player_id)}}

--- a/app/templates/roster.html
+++ b/app/templates/roster.html
@@ -154,7 +154,7 @@
     </thead>
     <tbody>
         {% for player_id, stats in batting_data.items() %}
-        {% if stats["PA"]>0 %}
+        {% if stats["PA"]>0 or stats["AB"]>0%}
         <tr>
             <td>
                 <a href={{"https://www.baseball-reference.com/players/{}/{}.shtml".format(player_id[0],player_id)}}


### PR DESCRIPTION
Batting stats for really old players weren't showing because it is filtered to PA>0 and you cant get PA for them bc some factors are null. Changed the check to filter PA>0 or AB>0, and that does the trick, still filtering it to people who actually batted, but also showing stats for old players.

Apologies, I think I somehow changed up the spacing too.